### PR TITLE
fix: Make the `firstVisit` logic actually work

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,34 +4,44 @@
 	import { ArrowUpIcon } from 'lucide-svelte';
 	import Loading from '../components/sections/Loading.svelte';
 
-	import { dev } from '$app/environment';
+	import { dev, browser } from '$app/environment';
 	import { inject } from '@vercel/analytics';
 
 	inject({ mode: dev ? 'development' : 'production' });
 
 	let showArrow = false;
-	let firstVisit = true;
+	let firstVisit = browser ? window.localStorage.getItem('firstVisit') === 'true' : null;
 
 	onMount(() => {
-		window.addEventListener('scroll', () => {
-			const threshold = 250;
-			showArrow = window.scrollY > threshold;
-		});
+		if (browser) {
+			firstVisit = window.localStorage.getItem('firstVisit') === 'true';
+			console.log(firstVisit);
 
-		setTimeout(() => {
-			firstVisit = false;
-		}, 1500);
+			window.addEventListener('scroll', () => {
+				const threshold = 250;
+				showArrow = window.scrollY > threshold;
+			});
+
+			setTimeout(() => {
+				firstVisit = false;
+				window.localStorage.setItem('firstVisit', 'false');
+			}, 1500);
+		}
 	});
 
 	function scrollToTop() {
-		window.scrollTo({ top: 0, behavior: 'smooth' });
+		if (browser) {
+			window.scrollTo({ top: 0, behavior: 'smooth' });
+		}
 	}
 </script>
 
 <main>
 	<div class="mx-auto min-h-screen px-4 py-5 md:px-12 md:py-20 lg:px-24 lg:py-0">
-		{#if firstVisit}
+		{#if firstVisit === true}
 			<Loading />
+		{:else if firstVisit === null}
+			{' '}
 		{:else}
 			<slot />
 		{/if}


### PR DESCRIPTION
Previously, the logic that showed a loading GIF on the first visit didn't do anything other than slow down the page, as the `firstVisit` variable was local and not stored in the browser, so it wouldn't persist between sessions. This repairs that by storing and retrieving the `firstVisit` variable from local storage, and defaulting it to true if it does not exist.